### PR TITLE
add tests to import_gtfs fun using testthat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,9 @@ Imports:
     data.table,
     utils,
     zip
+Suggests: 
+    covr,
+    testthat
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(gtfsio)
+
+test_check("gtfsio")

--- a/tests/testthat/test_import_gtfs.R
+++ b/tests/testthat/test_import_gtfs.R
@@ -1,0 +1,40 @@
+
+gtfszip <- system.file("extdata/ggl_gtfs.zip", package = "gtfsio")
+
+### expected behavior ----------------
+test_that("import_gtfs expected behavior", {
+
+  # whole file
+  testthat::expect_type(object = import_gtfs(gtfszip), type = 'list')
+
+  # selected files and fields
+  testthat::expect_type(object =  import_gtfs(path = gtfszip,
+                                     files = 'stops',
+                                     fields = list('stops'=c('stop_id')),
+                                     quiet = T),
+                        type = 'list')
+
+  # quiet argument
+  testthat::expect_type(object = import_gtfs(gtfszip, quiet = F),
+                        type = 'list')
+
+})
+
+### expected errors and messages ----------------
+
+test_that("import_gtfs errors and messages", {
+
+  # Wrong path
+  testthat::expect_error(import_gtfs(path = 'aaa'))
+  testthat::expect_error(import_gtfs(path = 1))
+
+  # Wrong file
+  testthat::expect_error(import_gtfs(path = gtfszip, files = 'aaa'))
+
+  # Wrong field
+  testthat::expect_warning(import_gtfs(path = gtfszip,
+                                     files = 'stops',
+                                     fields = list('stops'=c('aaa'))))
+  # wrong quiet
+  testthat::expect_error(import_gtfs(path = gtfszip, quiet = 'aaa'))
+  })


### PR DESCRIPTION
Here is the coverage resulf with the added tests. The warning below is realted to issue #4 

```R
library(covr)
library(testthat)
function_coverage(fun=gtfsio::import_gtfs, test_file("tests/testthat/test_import_gtfs.R"))

== Testing test_import_gtfs.R ==================================================
[ FAIL 0 | WARN 1 | SKIP 0 | PASS 8 ]

-- Warning (test_import_gtfs.R:32:3): import_gtfs errors and messages ---------------------
The provided GTFS feed doesn't contain the following text file(s): 'aaa'
Backtrace:
 1. testthat::expect_error(import_gtfs(path = gtfszip, files = "aaa")) test_import_gtfs.R:32:2
 6. gtfsio::import_gtfs(path = gtfszip, files = "aaa")

[ FAIL 0 | WARN 1 | SKIP 0 | PASS 8 ]
Coverage: 90.38%
R:/Dropbox/git/gtfsio/R/import_gtfs.R: 90.38%
```
