### PR TITLE
write to directory instead of renaming temp dir

### DIFF
--- a/R/export_gtfs.R
+++ b/R/export_gtfs.R
@@ -62,6 +62,9 @@ export_gtfs <- function(gtfs,
   if (!is.character(path) | length(path) != 1)
     stop("'path' must be a string (a character vector of length 1).")
 
+  if (path == tempdir())
+    stop("Please use 'path = tempfile()' instead of tempdir() to designate temporary directories")
+
   if (!is.null(files) & !is.character(files))
     stop("'files' must either be a character vector or NULL.")
 

--- a/R/export_gtfs.R
+++ b/R/export_gtfs.R
@@ -94,6 +94,10 @@ export_gtfs <- function(gtfs,
       "If you meant to create a directory please set 'as_dir' to TRUE."
     )
 
+  if (as_dir & grepl("\\.zip$", path)) {
+    stop("path cannot have '.zip' extension with as_dir=TRUE")
+  }
+
   extra_files <- setdiff(files, names(gtfs_standards))
   if (standard_only & !is.null(files) & !identical(extra_files, character(0)))
     stop(
@@ -130,11 +134,16 @@ export_gtfs <- function(gtfs,
       paste0("'", missing_files, "'", collapse = ", ")
     )
 
-  # create temp directory where files should be written to
-
-  tmpd <- tempfile(pattern = "gtfsio")
-  unlink(tmpd, recursive = TRUE)
-  dir.create(tmpd)
+  # use path or create temp directory where files should be written to
+  if (as_dir) {
+    tmpd <- path
+    unlink(tmpd, recursive = TRUE)
+    dir.create(tmpd)
+  } else {
+    tmpd <- tempfile(pattern = "gtfsio")
+    unlink(tmpd, recursive = TRUE)
+    dir.create(tmpd)
+  }
 
   # write files to 'tmpd'
 
@@ -172,19 +181,8 @@ export_gtfs <- function(gtfs,
   # directory, not a file
   # related issue: https://github.com/r-lib/zip/issues/76
 
-  unlink(path, recursive = TRUE)
-
-  # if 'as_dir' is TRUE, move 'tmpd' to 'path'. else, zip its content to 'path'
-
-  if (as_dir) {
-
+  if (!as_dir) {
     unlink(path, recursive = TRUE)
-    file.rename(tmpd, path)
-
-    if (!quiet)
-      message("GTFS directory successfully moved from ", tmpd, " to ", path)
-
-  } else {
 
     filepaths <- file.path(tmpd, paste0(files, ".txt"))
 

--- a/R/new_gtfs.R
+++ b/R/new_gtfs.R
@@ -20,7 +20,7 @@
 #' @examples
 #' gtfs_path <- system.file("extdata/ggl_gtfs.zip", package = "gtfsio")
 #'
-#' tmpdir <- file.path(tempdir(), "new_gtfs_example")
+#' tmpdir <- file.path(tempfile(), "new_gtfs_example")
 #' zip::unzip(gtfs_path, exdir = tmpdir)
 #'
 #' agency <- data.table::fread(file.path(tmpdir, "agency.txt"))

--- a/inst/tinytest/test_export_gtfs.R
+++ b/inst/tinytest/test_export_gtfs.R
@@ -103,7 +103,6 @@ expect_error(
 
 # object should be exported as a zip file by default
 
-file.remove(tmpf)
 export_gtfs(gtfs, tmpf)
 expect_true(file.exists(tmpf))
 expect_false(dir.exists(tmpf))
@@ -222,13 +221,10 @@ exist_pat <- paste0(
   "but 'overwrite' is set to FALSE\\."
 )
 
-invisible(file.create(tmpf))
+expect_true(file.exists(tmpf))
+expect_true(dir.exists(tmpd))
 expect_error(export_gtfs(gtfs, tmpf, overwrite = FALSE), pattern = exist_pat)
-invisible(file.remove(tmpf))
-dir.create(tmpd, showWarnings = FALSE)
 expect_error(export_gtfs(gtfs, tmpd, overwrite = FALSE), pattern = exist_pat)
-unlink(tmpd, recursive = TRUE)
-
 
 # 'quiet' behaviour -------------------------------------------------------
 
@@ -245,7 +241,10 @@ expect_true(any(grepl("^GTFS object successfully zipped to ", out)))
 
 # as_dir = TRUE
 
-expect_message(export_gtfs(gtfs, tmpd, as_dir = TRUE, quiet = FALSE))
+expect_error(export_gtfs(gtfs, tempdir(), as_dir = TRUE),
+             "Please use 'path = tempfile\\(\\)' instead of tempdir\\(\\) to designate temporary directories")
+
+expect_message(export_gtfs(gtfs, tmpf, as_dir = TRUE, quiet = FALSE))
 out <- capture.output(
   export_gtfs(gtfs, tmpd, as_dir = TRUE, quiet = FALSE),
   type = "message"

--- a/inst/tinytest/test_export_gtfs.R
+++ b/inst/tinytest/test_export_gtfs.R
@@ -244,7 +244,7 @@ expect_true(any(grepl("^GTFS object successfully zipped to ", out)))
 expect_error(export_gtfs(gtfs, tempdir(), as_dir = TRUE),
              "Please use 'path = tempfile\\(\\)' instead of tempdir\\(\\) to designate temporary directories")
 
-expect_message(export_gtfs(gtfs, tmpf, as_dir = TRUE, quiet = FALSE))
+expect_message(export_gtfs(gtfs, tmpd, as_dir = TRUE, quiet = FALSE))
 out <- capture.output(
   export_gtfs(gtfs, tmpd, as_dir = TRUE, quiet = FALSE),
   type = "message"

--- a/inst/tinytest/test_export_gtfs.R
+++ b/inst/tinytest/test_export_gtfs.R
@@ -245,11 +245,11 @@ expect_true(any(grepl("^GTFS object successfully zipped to ", out)))
 
 # as_dir = TRUE
 
-expect_message(export_gtfs(gtfs, tmpf, as_dir = TRUE, quiet = FALSE))
+expect_message(export_gtfs(gtfs, tmpd, as_dir = TRUE, quiet = FALSE))
 out <- capture.output(
-  export_gtfs(gtfs, tmpf, as_dir = TRUE, quiet = FALSE),
+  export_gtfs(gtfs, tmpd, as_dir = TRUE, quiet = FALSE),
   type = "message"
 )
 expect_true(any(grepl("^Writing text files to ", out)))
 expect_true(any(grepl("^  - Writing ", out)))
-expect_true(any(grepl("^GTFS directory successfully moved from ", out)))
+expect_true(any(grepl("^Writing text files to ", out)))

--- a/man/new_gtfs.Rd
+++ b/man/new_gtfs.Rd
@@ -29,7 +29,7 @@ on \code{gtfs} objects, thus inputs are not extensively checked. See
 \examples{
 gtfs_path <- system.file("extdata/ggl_gtfs.zip", package = "gtfsio")
 
-tmpdir <- file.path(tempdir(), "new_gtfs_example")
+tmpdir <- file.path(tempfile(), "new_gtfs_example")
 zip::unzip(gtfs_path, exdir = tmpdir)
 
 agency <- data.table::fread(file.path(tmpdir, "agency.txt"))

--- a/vignettes/gtfsio.Rmd
+++ b/vignettes/gtfsio.Rmd
@@ -116,7 +116,7 @@ Objects are written as `.zip` feeds by default, but you can also write them as d
 ```{r}
 gtfs <- import_gtfs(gtfs_path)
 tmpf <- tempfile(fileext = ".zip")
-tmpd <- tempdir()
+tmpd <- tempfile()
 
 export_gtfs(gtfs, tmpf)
 zip::zip_list(tmpf)$filename

--- a/vignettes/gtfsio.Rmd
+++ b/vignettes/gtfsio.Rmd
@@ -116,7 +116,7 @@ Objects are written as `.zip` feeds by default, but you can also write them as d
 ```{r}
 gtfs <- import_gtfs(gtfs_path)
 tmpf <- tempfile(fileext = ".zip")
-tmpd <- tempfile()
+tmpd <- tempdir()
 
 export_gtfs(gtfs, tmpf)
 zip::zip_list(tmpf)$filename


### PR DESCRIPTION
Currently `export_gtfs(as_dir = TRUE)` renames the created temporary folder. However, I ran into [issues with this approach](https://github.com/r-transit/tidytransit/pull/164/checks?check_run_id=2331498330):

```r
library(gtfsio)
path1 <- system.file("extdata", "sample-feed-fixed.zip", package = "tidytransit")
path2 <- tempdir()
g1 <- import_gtfs(path1)
export_gtfs(g1, path2, as_dir = TRUE)
#> Warning message:
#> In file.rename(tmpd, path) :
#>   cannot rename file '/var/folders/p8/ck58x_354mj8vgdcqyyz_r540000gn/T//RtmpR8xTkj/gtfsio5bc7fc71ddf' 
#>   to '/var/folders/p8/ck58x_354mj8vgdcqyyz_r540000gn/T//RtmpR8xTkj', reason 'No such file or directory'
```

With this PR `export_gtfs` now writes all files directly to `path` if `as_dir` is set to `TRUE` instead of writing it to a temporary directory and then renaming that directory to `path`. Is there any drawback to this approach that I'm missing?