### PR TITLE
escape characters in grep expressions

### DIFF
--- a/R/import_gtfs.R
+++ b/R/import_gtfs.R
@@ -75,7 +75,7 @@ import_gtfs <- function(path,
 
   if (!grepl("\\.zip$", path)) stop("'path' must have '.zip' extension.")
 
-  path_is_url <- grepl("^http[s]?://.*", path)
+  path_is_url <- grepl("^http[s]?\\:\\/\\/\\.*", path)
 
   if (!path_is_url & !file.exists(path))
     stop("'path' points to non-existent file: '", path, "'")
@@ -118,7 +118,7 @@ import_gtfs <- function(path,
   # retrieve which files are inside the GTFS and remove '.txt' from their names
 
   files_in_gtfs <- zip::zip_list(path)$filename
-  files_in_gtfs <- gsub(".txt", "", files_in_gtfs)
+  files_in_gtfs <- gsub("\\.txt", "", files_in_gtfs)
 
   # read only the text files specified either in 'files' or in 'skip'.
   # if both are NULL, read all text files


### PR DESCRIPTION
This is minor, but important. Characters including `.` and `:` have a special meaning in `regex`, and need to be specified as literal characters for R's `grep` to treat them as such. Without them, R will first try to interpret them as part of a `regex` command sequence, and if that fails (which it would here), will presume they are meant as string literals. This skips the first step, and tells R's interpreter to treat them just as literal strings.