### PR TITLE
Use mode = "wb" to download files without zip extension on Windows

### DIFF
--- a/R/import_gtfs.R
+++ b/R/import_gtfs.R
@@ -99,7 +99,7 @@ import_gtfs <- function(path,
 
   if (path_is_url) {
     tmp <- fs::file_temp(pattern = "gtfs", ext = ".zip")
-    utils::download.file(path, tmp, method = "auto", quiet = quiet)
+    utils::download.file(path, tmp, method = "auto", quiet = quiet, mode = "wb")
 
     if (!quiet) message("File downloaded to ", tmp, ".")
 

--- a/man/gtfs_reference.Rd
+++ b/man/gtfs_reference.Rd
@@ -27,7 +27,7 @@ gtfs_reference
 }
 \description{
 The data from the official GTFS specification document parsed to a list. Revision date:
-\code{2024-08-16}.
+\code{2024-12-05}.
 }
 \details{
 GTFS Types are converted to R types in gtfsio according to the following list:


### PR DESCRIPTION
As discussed here #50 